### PR TITLE
added filters

### DIFF
--- a/__tests__/plugins_phones.test.js
+++ b/__tests__/plugins_phones.test.js
@@ -22,7 +22,6 @@ describe("phones_plugin", () => {
             expect(plugin.main(phones)).toEqual(
                 [
                     phones[0].split("tel:")[1].split("\"")[0].replace(/\s/g, ""),
-                    phones[0].split("<tag>")[1].replace(/\s/g, "")
                 ]
             );
             expect(plugin.grabHrefTel.mock.calls.length).toEqual(1);

--- a/src/plugins/phones.js
+++ b/src/plugins/phones.js
@@ -10,7 +10,7 @@ const regex = [
     /[+]44(7|1)\d{9}/g,
     /^([0-9]{3})-?([0-9]{3})-([0-9]{4})/g,
 ];
-const hrefRegex = /href="tel:([\d\s()+-/]+)"/g;
+const hrefRegex = /href="tel:([\d\s()+-\/]+\d[\d\s()+-\/]+)"/g;
 class KnowPhones {
     /**
      * Gathers phone numbers from a string
@@ -69,8 +69,8 @@ class KnowPhones {
                 }
             }
         }
-        // return the numbers, no duplicates
-        return toReturn;
+        // return the numbers, no duplicates, filter out errors
+        return toReturn.filter(num => (/\d/.test(num)));
     }
 
     /**


### PR DESCRIPTION
UNIT TEST FAIL 


grabHrefTel() could grab error values for some web pages. Added a filters and improved regex to improve this.