### PR TITLE
Fix email regex

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "know-parser",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4380,9 +4380,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "know-parser",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "A simple, plugin-based parser for text",
   "repository": {
     "type": "git",

--- a/src/plugins/emails.js
+++ b/src/plugins/emails.js
@@ -1,4 +1,4 @@
-const regex = /(([^<>()\[\]\\.,;:\s@"'\/?=]+(?!png|jpg|jpeg|zvg)(\.[^<>()\[\]\\.,;:\s@"\/=?]+)*(?!png|jpg|jpeg|zvg)))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+((?!png|jpg|jpeg|zvg)[a-zA-Z]{2,})))/gi;
+const regex = /(([^<>()\[\]\\.,;:\s@"'\/?=#{}]+(?!png|jpg|jpeg|zvg)(\.[^<>()\[\]\\.,;:\s@"\/=?]+)*(?!png|jpg|jpeg|zvg)))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+((?!png|jpg|jpeg|zvg)[a-zA-Z]{2,})))/gi;
 /**
  * A know-parser plugin to gather email addresses
  *

--- a/src/plugins/emails.js
+++ b/src/plugins/emails.js
@@ -1,4 +1,4 @@
-const regex = /(([^<>()\[\]\\.,;:\s@"'\/?=#{}]+(?!png|jpg|jpeg|zvg)(\.[^<>()\[\]\\.,;:\s@"\/=?]+)*(?!png|jpg|jpeg|zvg)))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+((?!png|jpg|jpeg|zvg)[a-zA-Z]{2,})))/gi;
+const regex = /(([^<>()\[\]\\.,;:\s@"'\/?=#{}%]+(?!png|jpg|jpeg|zvg)(\.[^<>()\[\]\\.,;:\s@"\/=?]+)*(?!png|jpg|jpeg|zvg)))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+((?!png|jpg|jpeg|zvg)[a-zA-Z]{2,})))/gi;
 /**
  * A know-parser plugin to gather email addresses
  *


### PR DESCRIPTION
This is a PR directly from the fork - so theres some extra stuff such as package.json/themes

This aims at fixing some false flags on email regex and a security vuln

(you can also just use the offical know-parser version)